### PR TITLE
Error reporting

### DIFF
--- a/src/data/nmea_0183/core.clj
+++ b/src/data/nmea_0183/core.clj
@@ -7,4 +7,11 @@
   "Read and parse one sentence from the input source."
   [input]
   (let [{:keys [sentence fields] :as m} (msg/read-message input)]
-    (merge m (sentences/parse-sentence sentence fields))))
+    (when-not sentence (throw (ex-info "No identifiable NMEA sentence found"
+                                       {:type :parse-error})))
+    (try
+      (merge m (sentences/parse-sentence sentence fields))
+      (catch java.lang.IllegalArgumentException e
+        (throw (ex-info (str "Cannot parse sentence " sentence " fields " fields)
+                        {:type :parse-error}
+                        e))))))

--- a/src/data/nmea_0183/core.clj
+++ b/src/data/nmea_0183/core.clj
@@ -11,7 +11,7 @@
                                        {:type :parse-error})))
     (try
       (merge m (sentences/parse-sentence sentence fields))
-      (catch java.lang.IllegalArgumentException e
+      (catch Exception e
         (throw (ex-info (str "Cannot parse sentence " sentence " fields " fields)
                         {:type :parse-error}
                         e))))))

--- a/src/data/nmea_0183/fields.clj
+++ b/src/data/nmea_0183/fields.clj
@@ -70,6 +70,7 @@
   (let [spec (s/get-spec field-kw)]
     (when-not spec
       (throw (ex-info "Missing spec for field, this is a bug."
-                      {:field-kw field-kw})))
+                      {:type :internal-error
+                       :field-kw field-kw})))
     (when-not (str/blank? ascii-value)
       (t/from-ascii spec ascii-value))))


### PR DESCRIPTION
Current implementation throws many diverse Java exceptions when parsing fails or a nmea sentence is not supported. We need more concise error messages in our project. Code review done w/ @K1ll3rF0x 