### PR TITLE
Throws :unsupported-sentence for valid unsupported sentences

### DIFF
--- a/src/data/nmea_0183/core.clj
+++ b/src/data/nmea_0183/core.clj
@@ -7,8 +7,13 @@
   "Read and parse one sentence from the input source."
   [input]
   (let [{:keys [sentence fields] :as m} (msg/read-message input)]
-    (when-not sentence (throw (ex-info "No identifiable NMEA sentence found"
-                                       {:type :parse-error})))
+    (when-not sentence
+      (throw (ex-info "No identifiable NMEA sentence found"
+                      {:type :parse-error})))
+
+    (when-not (get-method sentences/parse-sentence sentence)
+      (throw (ex-info (str "Unsupported sentence " sentence)
+                      {:type :unsupported-sentence})))
     (try
       (merge m (sentences/parse-sentence sentence fields))
       (catch Exception e

--- a/src/data/nmea_0183/message.clj
+++ b/src/data/nmea_0183/message.clj
@@ -50,7 +50,7 @@
           (update :fields subvec 1)))
     (catch java.lang.StringIndexOutOfBoundsException e
       (throw (ex-info "Cannot identify talker and NMEA sentence"
-                      {:type :parse-error
+                      {:type :unsupported-sentence
                        :field (first fields)}
                       e)))))
 

--- a/test/data/nmea_0183/core_test.clj
+++ b/test/data/nmea_0183/core_test.clj
@@ -49,3 +49,18 @@
       ;; check only that the messages are parsed correctly
       ;; FIXME: could add more validation
       (is msgs))))
+
+(deftest parse-unsupported-sentence
+  (testing "Parsing unsupported sentence throws :unsupported-sentence"
+    (let [error (try (sut/parse (input "$GPGNS,120226.00,6304.8655,N,02134.3280,E,D,09,0.9,-2.4,23,8,0724,S*77"))
+                     (catch Exception e
+                       e))
+          msg (ex-data error)]
+      (is (= (:type msg) :unsupported-sentence) error)))
+
+  (testing "Parsing unsupported sentence without talker throws :unsupported-sentence"
+    (let [error (try (sut/parse (input "$PSAT,HPR,120227.00,206.89,3.19,-1.0,N*34"))
+                     (catch Exception e
+                       e))
+          msg (ex-data error)]
+      (is (= (:type msg) :unsupported-sentence)))))


### PR DESCRIPTION
Allows more granular error handling for clients by reporting separate error type for sentences not supported by this library.